### PR TITLE
Commit of WIP version of redis cache for review via PR

### DIFF
--- a/api/auth/index.js
+++ b/api/auth/index.js
@@ -31,7 +31,7 @@ function Auth (api) {
   }
 
   function getAccount (account, next) {
-    client.get(q(keyspace, 'selectAccount'), [account], {prepare: true}, function (err, result) {
+    client.get(q(keyspace, 'selectAccount'), [account], {prepare: true, cacheKey: 'account:' + account}, function (err, result) {
       if (err) { return next(err); }
       next(null, result);
     });
@@ -53,7 +53,7 @@ function Auth (api) {
 
   function updateAccount (account, name, isadmin, enabled, next) {
     var accountData = [name, isadmin, enabled, account];
-    client.execute(q(keyspace, 'updateAccount'), accountData, {prepare: true}, function (err, result) {
+    client.execute(q(keyspace, 'updateAccount'), accountData, {prepare: true, cacheKey: 'account:' + account}, function (err, result) {
       if (err) { return next(err); }
       next(null, {account: account, name: name, isadmin: isadmin, enabled: enabled});
     });
@@ -120,7 +120,7 @@ function Auth (api) {
    */
   function updateApplication (appid, name, enabled, next) {
     var application = [name, enabled, appid];
-    client.execute(q(keyspace, 'updateApplication'), application, {prepare: true}, function (err) {
+    client.execute(q(keyspace, 'updateApplication'), application, {prepare: true, cacheKey: 'application:' + appid}, function (err) {
       next(err, {name: name, appid: appid, enabled: enabled});
     });
   }
@@ -233,7 +233,7 @@ function Auth (api) {
       return next(new restify.UnauthorizedError('You must provide an token id via the Authorization header to access seguir the seguir API.'));
     }
     var token = [tokenid];
-    client.get(q(keyspace, 'checkApplicationToken'), token, {prepare: true}, function (err, result) {
+    client.get(q(keyspace, 'checkApplicationToken'), token, {prepare: true, cacheKey: 'token:' + tokenid}, function (err, result) {
       var token = result;
       if (err) { return next(err); }
       if (!token || !token.enabled) { return next(null, null); }
@@ -242,7 +242,7 @@ function Auth (api) {
   }
 
   function getUserBySeguirId (user_keyspace, user, next) {
-    client.get(q(user_keyspace, 'selectUser'), [user], {prepare: true}, function (err, result) {
+    client.get(q(user_keyspace, 'selectUser'), [user], {prepare: true, cacheKey: 'user:' + user}, function (err, result) {
       if (err) { return next(err); }
       if (!result) { return next(new restify.InvalidArgumentError('Specified user by seguir id "' + user + '" in header "' + userHeader + '" does not exist.')); }
       next(null, result);

--- a/api/user/index.js
+++ b/api/user/index.js
@@ -109,6 +109,7 @@ module.exports = function (api) {
     var user = [username, '' + altid, userdata, userid];
     client.execute(q(keyspace, 'updateUser'), user, {
       prepare: true,
+      cacheKey: 'user:' + userid,
       hints: [null, null, 'map']
     }, function (err, result) {
       if (err) { return next(err); }
@@ -117,15 +118,15 @@ module.exports = function (api) {
   }
 
   function getUser (keyspace, user, next) {
-    api.common.get(keyspace, 'selectUser', [user], 'one', next);
+    client.get(q(keyspace, 'selectUser'), [user], {cacheKey: 'user:' + user}, next);
   }
 
   function getUserByName (keyspace, username, next) {
-    api.common.get(keyspace, 'selectUserByUsername', [username], 'one', next);
+    client.get(q(keyspace, 'selectUserByUsername'), [username], next);
   }
 
   function getUserByAltId (keyspace, altid, next) {
-    api.common.get(keyspace, 'selectUserByAltId', ['' + altid], 'one', next);
+    client.get(q(keyspace, 'selectUserByAltId'), ['' + altid], next);
   }
 
   function mapUserIdToUser (keyspace, itemOrItems, fields, currentUser, next) {

--- a/db/cassandra/cache/index.js
+++ b/db/cassandra/cache/index.js
@@ -11,6 +11,7 @@ var _ = require('lodash');
 var cassandra = require('cassandra-driver');
 var Uuid = cassandra.types.Uuid;
 var debug = require('debug')('seguir:cassandra:cache');
+var UUID_COLUMNS = ['post', 'user', 'follow', 'user_follower', 'friend', 'user_friend', 'friend_request', 'like'];
 
 module.exports = function (config, next) {
 
@@ -42,7 +43,7 @@ module.exports = function (config, next) {
 
     // Convert all of the Cassandra IDs
     var clone = _.clone(object);
-    ['post', 'user', 'follow', 'friend', 'like'].forEach(function (item) {
+    UUID_COLUMNS.forEach(function (item) {
       if (clone[item]) { clone[item] = clone[item].toString(); }
     });
 
@@ -60,7 +61,7 @@ module.exports = function (config, next) {
   var from_cache = function (clone) {
 
     // Convert all of the Cassandra IDs back
-    ['post', 'user', 'follow', 'friend', 'like'].forEach(function (item) {
+    UUID_COLUMNS.forEach(function (item) {
       if (clone[item]) { clone[item] = Uuid.fromString(clone[item]); }
     });
 

--- a/db/cassandra/cache/index.js
+++ b/db/cassandra/cache/index.js
@@ -60,6 +60,8 @@ module.exports = function (config, next) {
 
   var from_cache = function (clone) {
 
+    if (!clone) return;
+
     // Convert all of the Cassandra IDs back
     UUID_COLUMNS.forEach(function (item) {
       if (clone[item]) { clone[item] = Uuid.fromString(clone[item]); }

--- a/db/cassandra/cache/index.js
+++ b/db/cassandra/cache/index.js
@@ -1,0 +1,118 @@
+/**
+ * Cassandra doesn't do joins, so we use a cache for GETs.
+ *
+ * This configuration simply looks for a 'redis' config key, if it exists it will use it as a cache.
+ *
+ * GET - cache(key, next);
+ * SET - cache(key, value, next);
+ */
+
+var FIVE_MINUTES = 60 * 5;
+var redis = require('../../redis');
+var _ = require('lodash');
+var cassandra = require('cassandra-driver');
+var Uuid = cassandra.types.Uuid;
+var debug = require('debug')('seguir:cassandra:cache');
+
+module.exports = function (config, next) {
+
+  var noCache = function (key, value, cb) {
+    if (!cb) { cb = value; value = null; }
+    if (!cb) { cb = key; key = null; }
+    cb(null, value);
+  };
+
+  // If no redis config, simply return a miss always
+  var hasRedisConfig = config && config.redis;
+  if (!hasRedisConfig) { return next(null, {get: noCache, set: noCache, del: noCache, flush: noCache}); }
+
+  var redisClient = redis(config.redis);
+
+  var to_persist = function (object) {
+
+    if (!object) return;
+
+    // Convert all of the Cassandra IDs
+    var clone = _.clone(object);
+    ['post', 'user', 'follow', 'friend', 'like'].forEach(function (item) {
+      if (clone[item]) { clone[item] = clone[item].toString(); }
+    });
+
+    // Convert any embedded object to JSON
+    if (clone.userdata) { clone.userdata = JSON.stringify(clone.userdata); }
+
+    // Convert any timestamps to ISO strings
+    if (clone.since) { clone.since = clone.since.toISOString(); }
+    if (clone.posted) { clone.posted = clone.posted.toISOString(); }
+
+    return clone;
+
+  };
+
+  var from_persist = function (clone) {
+
+    // Convert all of the Cassandra IDs back
+    ['post', 'user', 'follow', 'friend', 'like'].forEach(function (item) {
+      if (clone[item]) { clone[item] = Uuid.fromString(clone[item]); }
+    });
+
+    // Convert any embedded object from JSON
+    if (clone.userdata) { clone.userdata = JSON.parse(clone.userdata); }
+
+    // Convert any timestamps back from strings
+    if (clone.since) { clone.since = new Date(clone.since); }
+    if (clone.posted) { clone.posted = new Date(clone.posted); }
+
+    return clone;
+  };
+
+  var set = function (key, value, cb) {
+    if (!key) { return cb(null, value); }
+    debug('SET', key);
+    redisClient.multi()
+      .hmset(key, to_persist(value))
+      .expire(key, FIVE_MINUTES)
+      .exec(function (err) {
+        if (err) { /* Purposeful ignore of err */ }
+        cb(null, value);
+      });
+  };
+
+  var del = function (key, cb) {
+    if (!key) { return cb(null); }
+    debug('DEL', key);
+    redisClient.del(key, function (err) {
+      if (err) { /* Purposeful ignore of err */ }
+      cb(null);
+    });
+  };
+
+  var flush = function (cb) {
+    debug('FLUSH');
+    redisClient.flushdb(function (err) {
+      if (err) { /* Purposeful ignore of err */ }
+      cb(null);
+    });
+  };
+
+  var get = function (key, cb) {
+    if (!key) { return cb(null); }
+    debug('GET', key);
+    redisClient.hgetall(key, function (err, object) {
+      if (err) { /* Purposeful ignore of err */ }
+      debug(object ? 'HIT' : 'MISS', key);
+      cb(null, object ? from_persist(object) : null);
+    });
+  };
+
+  var cache = {
+    get: get,
+    set: set,
+    del: del,
+    flush: flush
+  };
+
+  next(null, cache);
+
+};
+

--- a/db/cassandra/index.js
+++ b/db/cassandra/index.js
@@ -4,112 +4,149 @@ var TimeUuid = cassandra.types.TimeUuid;
 var path = require('path');
 var debug = require('debug')('seguir:cassandra');
 var debugDriver = require('debug')('cassandra:driver');
+var redisCache = require('./cache');
 
 function createClient (config, next) {
 
-  var cassandraConfig = config && config.cassandra;
-  var client = new cassandra.Client(cassandraConfig);
-  client.on('log', function (level, className, message, furtherInfo) {
-    debugDriver('log event: %s -- %s', level, message);
-  });
+  redisCache(config, function (err, cache) {
 
-  function get (query, data, options, next) {
-    if (!next) { next = options; options = null; }
-    if (!next) { next = data; data = null; }
-    if (!query) { return next(null); }
-    debug('get', query, data);
-    client.execute(query, data, options, function (err, result) {
-      if (err) { return next(err); }
-      next(null, result && result.rows ? result.rows[0] : null);
+    if (err) {
+      console.log('Failed to initialise redis cache: ' + err);
+    }
+
+    var cassandraConfig = config && config.cassandra;
+    var client = new cassandra.Client(cassandraConfig);
+    client.on('log', function (level, className, message, furtherInfo) {
+      debugDriver('log event: %s -- %s', level, message);
     });
-  }
 
-  function execute (query, data, options, next) {
-    var self = this;
-    if (!next) { next = options; options = null; }
-    if (!next) { next = data; data = null; }
-    if (!query) { return next(null); }
-    debug('execute', query, data);
-    client.execute(query, data, options, function (err, result) {
-      if (err) {
-        if (self.truncate && err.message.indexOf('No secondary indexes on the restricted columns') >= 0) {
-          // This error occurs after failures in index creation, so in test / truncate mode
-          // we need to trigger that the tests rebuild the DB on next go around
-          // See https://github.com/cliftonc/seguir/issues/15
-          var keyspace = query.split('FROM ')[1].split('.')[0];
-          if (keyspace) {
-            console.log('Truncating schema version to recover from index failure ...');
-            return execute('TRUNCATE ' + keyspace + '.schema_version;', function () {
-              next(err);
-            });
-          }
+    function get (query, data, options, next) {
+      if (!next) { next = options; options = {}; }
+      if (!next) { next = data; data = null; }
+      if (!query) { return next(null); }
+
+      // Send the cache key with the options, but remove to
+      // ensure we don't confuse cassandra.
+      var cacheKey = options.cacheKey;
+      delete options.cacheKey;
+
+      debug('get', query, data);
+      cache.get(cacheKey, function (err, cachedResult) {
+        if (err) { /* Purposeful ignore of err */ }
+        if (cachedResult) {
+          return next(null, cachedResult);
         }
-        return next(err);
-      }
-      next(null, result && result.rows ? result.rows : null);
-    });
-  }
+        client.execute(query, data, options, function (err, result) {
+          if (err) { return next(err); }
+          var item = result && result.rows ? result.rows[0] : null;
+          cache.set(cacheKey, item, next);
+        });
+      });
+    }
 
-  function generateId (uuid) {
-    if (uuid) {
-      if (isUuid(uuid)) {
-        return uuid;
+    function execute (query, data, options, next) {
+      var self = this;
+      if (!next) { next = options; options = {}; }
+      if (!next) { next = data; data = null; }
+      if (!query) { return next(null); }
+
+      // Send the cache key with the options, but remove to
+      // ensure we don't confuse cassandra.
+      var cacheKey = options.cacheKey;
+      delete options.cacheKey;
+
+      debug('execute', query, data);
+      client.execute(query, data, options, function (err, result) {
+        if (err) {
+          if (self.truncate && err.message.indexOf('No secondary indexes on the restricted columns') >= 0) {
+            // This error occurs after failures in index creation, so in test / truncate mode
+            // we need to trigger that the tests rebuild the DB on next go around
+            // See https://github.com/cliftonc/seguir/issues/15
+            var keyspace = query.split('FROM ')[1].split('.')[0];
+            if (keyspace) {
+              console.log('Truncating schema version to recover from index failure ...');
+              return execute('TRUNCATE ' + keyspace + '.schema_version;', function () {
+                next(err);
+              });
+            }
+          }
+          return next(err);
+        }
+
+        var resultObject = result && result.rows ? result.rows : null;
+
+        // Clear the cache on executes if we have a cache key
+        cache.del(cacheKey, function () {
+          next(null, resultObject);
+        });
+
+      });
+    }
+
+    function generateId (uuid) {
+      if (uuid) {
+        if (isUuid(uuid)) {
+          return uuid;
+        } else {
+          return Uuid.fromString(uuid);
+        }
       } else {
-        return Uuid.fromString(uuid);
+        return Uuid.random();
       }
-    } else {
-      return Uuid.random();
     }
-  }
 
-  function generateTimeId (timestamp) {
-    if (timestamp) {
-      return TimeUuid.fromDate(timestamp);
-    } else {
-      return TimeUuid.now();
+    function generateTimeId (timestamp) {
+      if (timestamp) {
+        return TimeUuid.fromDate(timestamp);
+      } else {
+        return TimeUuid.now();
+      }
     }
-  }
 
-  function isUuid (value) {
-    return value instanceof Uuid;
-  }
-
-  function isStringUuid (value) {
-    return (typeof value === 'string' && value.length === 36 && (value.match(/-/g) || []).length === 4);
-  }
-
-  function isValidId (value) {
-    return isUuid(value) || isStringUuid(value);
-  }
-
-  function formatId (value) {
-    if (isUuid(value)) {
-      return value;
-    } else {
-      return generateId(value);
+    function isUuid (value) {
+      return value instanceof Uuid;
     }
-  }
 
-  function getTimestamp (value) {
-    return value ? new Date(value) : new Date();
-  }
+    function isStringUuid (value) {
+      return (typeof value === 'string' && value.length === 36 && (value.match(/-/g) || []).length === 4);
+    }
 
-  client.connect(function () {
-    next(null, {
-      type: 'cassandra',
-      config: cassandraConfig,
-      _client: client,
-      get: get,
-      execute: execute,
-      generateId: generateId,
-      generateTimeId: generateTimeId,
-      isValidId: isValidId,
-      formatId: formatId,
-      getTimestamp: getTimestamp,
-      migrations: path.resolve(__dirname, 'migrations'),
-      queries: require('./queries'),
-      setup: require('./setup')
+    function isValidId (value) {
+      return isUuid(value) || isStringUuid(value);
+    }
+
+    function formatId (value) {
+      if (isUuid(value)) {
+        return value;
+      } else {
+        return generateId(value);
+      }
+    }
+
+    function getTimestamp (value) {
+      return value ? new Date(value) : new Date();
+    }
+
+    client.connect(function () {
+      next(null, {
+        type: 'cassandra',
+        config: cassandraConfig,
+        _client: client,
+        get: get,
+        execute: execute,
+        deleteCacheItem: cache.del,
+        flushCache: cache.flush,
+        generateId: generateId,
+        generateTimeId: generateTimeId,
+        isValidId: isValidId,
+        formatId: formatId,
+        getTimestamp: getTimestamp,
+        migrations: path.resolve(__dirname, 'migrations'),
+        queries: require('./queries'),
+        setup: require('./setup')
+      });
     });
+
   });
 
 }

--- a/db/cassandra/index.js
+++ b/db/cassandra/index.js
@@ -11,7 +11,7 @@ function createClient (config, next) {
   redisCache(config, function (err, cache) {
 
     if (err) {
-      console.log('Failed to initialise redis cache: ' + err);
+      /* Purposeful ignore of err - never sent */
     }
 
     var cassandraConfig = config && config.cassandra;

--- a/db/cassandra/setup/helpers.js
+++ b/db/cassandra/setup/helpers.js
@@ -119,7 +119,8 @@ module.exports = function (client, options) {
     createSecondaryIndexes: createSecondaryIndexes,
     assertIndexes: assertIndexes,
     initialiseSchemaVersion: initialiseSchemaVersion,
-    truncate: truncate
+    truncate: truncate,
+    flushCache: client.flushCache
   };
 
 };

--- a/db/cassandra/setup/helpers.js
+++ b/db/cassandra/setup/helpers.js
@@ -46,7 +46,9 @@ module.exports = function (client, options) {
       } else {
         cb();
       }
-    }, next);
+    }, function () {
+      flushCache(next);
+    });
   }
 
   /* istanbul ignore next */
@@ -112,6 +114,10 @@ module.exports = function (client, options) {
     });
   }
 
+  function flushCache (next) {
+    client.flushCache(next);
+  }
+
   return {
     dropKeyspace: dropKeyspace,
     createKeyspace: createKeyspace,
@@ -120,7 +126,7 @@ module.exports = function (client, options) {
     assertIndexes: assertIndexes,
     initialiseSchemaVersion: initialiseSchemaVersion,
     truncate: truncate,
-    flushCache: client.flushCache
+    flushCache: flushCache
   };
 
 };

--- a/db/cassandra/setup/setupTenant.js
+++ b/db/cassandra/setup/setupTenant.js
@@ -174,6 +174,7 @@ function setup (client, keyspace, truncateIfExists, next) {
     helpers.createKeyspace,
     helpers.createTables,
     helpers.createSecondaryIndexes,
+    helpers.flushCache,
     async.apply(helpers.initialiseSchemaVersion, schemaVersion),
     async.retry(5, helpers.assertIndexes.bind(helpers.assertIndexes))
   ], function (err, data) {

--- a/db/messaging/index.js
+++ b/db/messaging/index.js
@@ -1,4 +1,4 @@
-var redis = require('redis');
+var redis = require('../redis');
 var _ = require('lodash');
 var RSMQ = require('rsmq');
 var RSMQWorker = require('rsmq-worker');
@@ -97,20 +97,7 @@ module.exports = function (config) {
 function client (config) {
 
   var redisConfig = config && config.messaging ? config.messaging : {};
-  redisConfig = _.defaults(config && config.messaging || {}, { host: 'localhost', port: 6379, options: { } });
-  redisConfig.options.retry_max_delay = redisConfig.options.retry_max_delay || 10000;
-
-  var redisClient = redis.createClient(redisConfig.port, redisConfig.host, redisConfig.options);
-
-  redisClient.on('error', function (err) {
-    console.error('Error connecting to redis [%s:%s] - %s', redisConfig.host, redisConfig.port, err.message);
-  });
-
-  redisClient.on('ready', function () {
-    // Do nothing - assume success unless proven otherwise
-  });
-
-  redisClient.select(redisConfig.db || 0);
+  var redisClient = redis(redisConfig);
 
   // Keep a reference to it for later shutdown
   clients.push(redisClient);

--- a/db/postgres/index.js
+++ b/db/postgres/index.js
@@ -63,11 +63,18 @@ function createClient (config, next) {
     return value;
   }
 
+  function noOpCache (key, cb) {
+    if (!cb) { cb = key; key = null; }
+    cb();
+  }
+
   next(null, {
     type: 'postgres',
     config: pgConfig,
     get: get,
     execute: execute,
+    deleteCacheItem: noOpCache,
+    flushCache: noOpCache,
     generateId: generateId,
     generateTimeId: generateTimeId,
     isValidId: isValidId,

--- a/db/redis/index.js
+++ b/db/redis/index.js
@@ -16,10 +16,6 @@ module.exports = function client (config) {
     console.error('Error connecting to redis [%s:%s] - %s', redisConfig.host, redisConfig.port, err.message);
   });
 
-  redisClient.on('ready', function () {
-    // Do nothing - assume success unless proven otherwise
-  });
-
   redisClient.select(redisConfig.db || 0);
 
   return redisClient;

--- a/db/redis/index.js
+++ b/db/redis/index.js
@@ -1,0 +1,27 @@
+/**
+ * Create a redis client
+ */
+
+var _ = require('lodash');
+var redis = require('redis');
+
+module.exports = function client (config) {
+
+  var redisConfig = _.defaults(config || {}, { host: 'localhost', port: 6379, options: { } });
+  redisConfig.options.retry_max_delay = redisConfig.options.retry_max_delay || 10000;
+
+  var redisClient = redis.createClient(redisConfig.port, redisConfig.host, redisConfig.options);
+
+  redisClient.on('error', function (err) {
+    console.error('Error connecting to redis [%s:%s] - %s', redisConfig.host, redisConfig.port, err.message);
+  });
+
+  redisClient.on('ready', function () {
+    // Do nothing - assume success unless proven otherwise
+  });
+
+  redisClient.select(redisConfig.db || 0);
+
+  return redisClient;
+
+};

--- a/tests/acceptance/api/auth.test.js
+++ b/tests/acceptance/api/auth.test.js
@@ -16,7 +16,7 @@ databases.forEach(function (db) {
   var config = _.clone(require('../../fixtures/' + db + '.json'));
   config.keyspace = keyspace;
 
-  describe('Account and Application Management - ' + db, function () {
+  describe('API [Account and Application] - ' + db, function () {
 
     var api, auth, accountId, userId, appId, tokenId;
 

--- a/tests/acceptance/api/auth.test.js
+++ b/tests/acceptance/api/auth.test.js
@@ -8,7 +8,7 @@ var expect = require('expect.js');
 var Api = require('../../../api');
 var authUtils = require('../../../api/auth/utils');
 var _ = require('lodash');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra-redis'];
 var keyspace = 'test_seguir_auth';
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/auth.test.js
+++ b/tests/acceptance/api/auth.test.js
@@ -8,7 +8,7 @@ var expect = require('expect.js');
 var Api = require('../../../api');
 var authUtils = require('../../../api/auth/utils');
 var _ = require('lodash');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
 var keyspace = 'test_seguir_auth';
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/feeds.test.js
+++ b/tests/acceptance/api/feeds.test.js
@@ -12,7 +12,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/feeds.test.js
+++ b/tests/acceptance/api/feeds.test.js
@@ -12,7 +12,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/follow.test.js
+++ b/tests/acceptance/api/follow.test.js
@@ -7,7 +7,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/follow.test.js
+++ b/tests/acceptance/api/follow.test.js
@@ -7,7 +7,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/friends.test.js
+++ b/tests/acceptance/api/friends.test.js
@@ -7,7 +7,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/friends.test.js
+++ b/tests/acceptance/api/friends.test.js
@@ -7,7 +7,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/likes.test.js
+++ b/tests/acceptance/api/likes.test.js
@@ -7,7 +7,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/likes.test.js
+++ b/tests/acceptance/api/likes.test.js
@@ -7,7 +7,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/posts.test.js
+++ b/tests/acceptance/api/posts.test.js
@@ -7,7 +7,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/posts.test.js
+++ b/tests/acceptance/api/posts.test.js
@@ -7,7 +7,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/relationships.test.js
+++ b/tests/acceptance/api/relationships.test.js
@@ -7,7 +7,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/relationships.test.js
+++ b/tests/acceptance/api/relationships.test.js
@@ -7,7 +7,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/users.test.js
+++ b/tests/acceptance/api/users.test.js
@@ -90,6 +90,23 @@ databases.forEach(function (db) {
         });
       });
 
+      it('can update a users data and it clears any cache', function (done) {
+        api.user.getUserByAltId(keyspace, users['cliftonc'].altid, function (err, user) {
+          expect(err).to.be(null);
+          api.user.updateUser(keyspace, users['cliftonc'].user, 'cliftonc', '1', {goodbye: 'world'}, function (err, user) {
+            expect(err).to.be(null);
+            api.user.getUserByAltId(keyspace, users['cliftonc'].altid, function (err, user) {
+              expect(err).to.be(null);
+              expect(user.user).to.eql(users['cliftonc'].user);
+              expect(user.username).to.be('cliftonc');
+              expect(user.userdata.goodbye).to.be('world');
+              expect(user.userdata.hello).to.be(undefined);
+              done();
+            });
+          });
+        });
+      });
+
       it('cant create a second user with the same altid', function (done) {
         api.user.addUser(keyspace, 'altido', '1', function (err, user) {
           expect(err.statusCode).to.be(409);

--- a/tests/acceptance/api/users.test.js
+++ b/tests/acceptance/api/users.test.js
@@ -6,7 +6,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/api/users.test.js
+++ b/tests/acceptance/api/users.test.js
@@ -6,7 +6,7 @@
 var keyspace = 'test_seguir_app_api';
 var expect = require('expect.js');
 var initialiser = require('../../fixtures/initialiser');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra', 'cassandra-redis'];
 var _ = require('lodash');
 
 databases.forEach(function (db) {

--- a/tests/acceptance/server/server.test.js
+++ b/tests/acceptance/server/server.test.js
@@ -23,7 +23,7 @@ var initialiser = require('../../fixtures/initialiser');
 var async = require('async');
 var fs = require('fs');
 var hbs = require('handlebars');
-var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres', 'cassandra'];
+var databases = process.env.DATABASE ? [process.env.DATABASE] : ['postgres'];
 
 databases.forEach(function (db) {
 

--- a/tests/fixtures/cassandra-redis.json
+++ b/tests/fixtures/cassandra-redis.json
@@ -1,0 +1,13 @@
+{
+  "logging": false,
+  "port":3000,
+  "keyspace":"seguir",
+  "cassandra": {
+    "contactPoints": ["0.0.0.0"]
+  },
+  "redis": {
+    "host": "127.0.0.1",
+    "port": 6379,
+    "db": 3
+  }
+}

--- a/tests/fixtures/initialiser.js
+++ b/tests/fixtures/initialiser.js
@@ -20,9 +20,7 @@ function setupApi (keyspace, config, next) {
       api.client.truncate = truncate;
       api.client.setup.setupTenant(api.client, keyspace, truncate, function (err) {
         if (err) { return next(err); }
-        setTimeout(function () {
-          next(null, api);
-        }, truncate ? 0 : 2000);
+        next(null, api);
       });
     });
   });
@@ -47,9 +45,7 @@ function setupServer (config, keyspace, next) {
                 credentials.appsecret = token.tokensecret;
                 var client = new Seguir(credentials);
                 process.stdout.write('.\n');
-                setTimeout(function () {
-                  next(null, api, server, client);
-                }, 5000);
+                next(null, api, server, client);
               });
             });
           });

--- a/tests/fixtures/initialiser.js
+++ b/tests/fixtures/initialiser.js
@@ -10,6 +10,7 @@ var _ = require('lodash');
 var credentials = {host: 'http://localhost:3001'};
 
 function setupApi (keyspace, config, next) {
+
   Api(config, function (err, api) {
     if (err) { return next(err); }
     console.log('   Setting up keyspace in ' + api.client.type + '...');

--- a/tests/fixtures/initialiser.js
+++ b/tests/fixtures/initialiser.js
@@ -20,7 +20,9 @@ function setupApi (keyspace, config, next) {
       api.client.truncate = truncate;
       api.client.setup.setupTenant(api.client, keyspace, truncate, function (err) {
         if (err) { return next(err); }
-        next(null, api);
+        setTimeout(function () {
+          next(null, api);
+        }, truncate ? 0 : 2000);
       });
     });
   });
@@ -45,7 +47,9 @@ function setupServer (config, keyspace, next) {
                 credentials.appsecret = token.tokensecret;
                 var client = new Seguir(credentials);
                 process.stdout.write('.\n');
-                next(null, api, server, client);
+                setTimeout(function () {
+                  next(null, api, server, client);
+                }, 5000);
               });
             });
           });


### PR DESCRIPTION
Ok ... wanted to get this up:

- Tried to add it in a way that it was easily controllable from each of the api areas (e.g. you have to opt in via specifying a cacheKey.
- It caches on a get, and clears on an execute (this is due to the fact that updates occur via execute, as do other multi-record requests).
- The cache object ignores errors - may feel like a bad smell, but given it is a pass through cache on error it just hits cassandra.  No clean way of logging stuff out directly from within the api atm.